### PR TITLE
Add CDT abbreviation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cdt-builds
 
-conda-forge CDT builds
+conda-forge Core Dependency Tree (CDT) builds
 
 
 ## Adding a CDT package


### PR DESCRIPTION
I saw the announcement on gitter which brought me to this repository where something felt wrong about "Core Dependency Tree" not appearing anywhere in this repository. Feel free to close without merging (I'm just procrastinating on my actual work).

Checklist:

- [ ] if you have added a CDT, it appears in the `cdt_slugs.yaml` file
- [ ] if you have changed the CDT generator code (`rpm.py`), you have bumped
  the build number in `conda_build_config.yaml` and have remade all of the
  recipes via running `python gen_cdt_recipes.py`
- [ ] if you have added a custom CDT recipe, you have added the name of the CDT
  with `custom: true` in the `cdt_slugs.yaml` file.
- [ ] all CDT recipes have build number set by `{{ cdt_build_number }}` for
  old-style/legacy CDTs or `{{ cdt_build_number|int + 1000 }}` for new-style CDTs
- [ ] if you see a warning about a CDT not having a license, you have added the
  `license_file` key in the `cdt_slugs.yaml` file with the path to the appropriate
  license in `licenses/`
