### PR TITLE
BUG fix host sections to pull right CDT builds

### DIFF
--- a/build_cdt_recipes.py
+++ b/build_cdt_recipes.py
@@ -169,7 +169,7 @@ def _build_all_cdts(cdt_path, custom_cdt_path, dist_arch_slug):
         )
 
     build_logs = ""
-    with ThreadPoolExecutor(max_workers=16) as exec:
+    with ThreadPoolExecutor(max_workers=4) as exec:
 
         skipped = set()
         for node in cdt_meta:

--- a/cdts/chkconfig-cos6-x86_64/build.sh
+++ b/cdts/chkconfig-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/chkconfig-cos7-aarch64/build.sh
+++ b/cdts/chkconfig-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/chkconfig-cos7-ppc64le/build.sh
+++ b/cdts/chkconfig-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/chkconfig-cos7-x86_64/build.sh
+++ b/cdts/chkconfig-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/kernel-headers-cos6-x86_64/build.sh
+++ b/cdts/kernel-headers-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/kernel-headers-cos7-aarch64/build.sh
+++ b/cdts/kernel-headers-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/kernel-headers-cos7-ppc64le/build.sh
+++ b/cdts/kernel-headers-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/kernel-headers-cos7-x86_64/build.sh
+++ b/cdts/kernel-headers-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libdrm-devel-cos6-x86_64/build.sh
+++ b/cdts/libdrm-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libdrm-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libdrm-devel-cos6-x86_64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - kernel-headers-cos6-x86_64 >=2.6.27
-    - libdrm-cos6-x86_64 ==2.4.65
+    - kernel-headers-cos6-x86_64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos6-x86_64 ==2.4.65 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - kernel-headers-cos6-x86_64 >=2.6.27
-    - libdrm-cos6-x86_64 ==2.4.65
+    - kernel-headers-cos6-x86_64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos6-x86_64 ==2.4.65 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - kernel-headers-cos6-x86_64 >=2.6.27
-    - libdrm-cos6-x86_64 ==2.4.65
+    - kernel-headers-cos6-x86_64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos6-x86_64 ==2.4.65 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libdrm-devel-cos7-aarch64/build.sh
+++ b/cdts/libdrm-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libdrm-devel-cos7-aarch64/meta.yaml
+++ b/cdts/libdrm-devel-cos7-aarch64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - kernel-headers-cos7-aarch64 >=2.6.27
-    - libdrm-cos7-aarch64 ==2.4.97
+    - kernel-headers-cos7-aarch64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-aarch64 ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - kernel-headers-cos7-aarch64 >=2.6.27
-    - libdrm-cos7-aarch64 ==2.4.97
+    - kernel-headers-cos7-aarch64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-aarch64 ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - kernel-headers-cos7-aarch64 >=2.6.27
-    - libdrm-cos7-aarch64 ==2.4.97
+    - kernel-headers-cos7-aarch64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-aarch64 ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libdrm-devel-cos7-ppc64le/build.sh
+++ b/cdts/libdrm-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libdrm-devel-cos7-ppc64le/meta.yaml
+++ b/cdts/libdrm-devel-cos7-ppc64le/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - kernel-headers-cos7-ppc64le >=2.6.27
-    - libdrm-cos7-ppc64le ==2.4.97
+    - kernel-headers-cos7-ppc64le >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-ppc64le ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - kernel-headers-cos7-ppc64le >=2.6.27
-    - libdrm-cos7-ppc64le ==2.4.97
+    - kernel-headers-cos7-ppc64le >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-ppc64le ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - kernel-headers-cos7-ppc64le >=2.6.27
-    - libdrm-cos7-ppc64le ==2.4.97
+    - kernel-headers-cos7-ppc64le >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-ppc64le ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libdrm-devel-cos7-x86_64/build.sh
+++ b/cdts/libdrm-devel-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libdrm-devel-cos7-x86_64/meta.yaml
+++ b/cdts/libdrm-devel-cos7-x86_64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - kernel-headers-cos7-x86_64 >=2.6.27
-    - libdrm-cos7-x86_64 ==2.4.97
+    - kernel-headers-cos7-x86_64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-x86_64 ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - kernel-headers-cos7-x86_64 >=2.6.27
-    - libdrm-cos7-x86_64 ==2.4.97
+    - kernel-headers-cos7-x86_64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-x86_64 ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - kernel-headers-cos7-x86_64 >=2.6.27
-    - libdrm-cos7-x86_64 ==2.4.97
+    - kernel-headers-cos7-x86_64 >=2.6.27 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos7-x86_64 ==2.4.97 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/libibcm-cos6-x86_64/build.sh
+++ b/cdts/libibcm-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libibcm-devel-cos6-x86_64/build.sh
+++ b/cdts/libibcm-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libibcm-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libibcm-devel-cos6-x86_64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libibcm-cos6-x86_64 ==1.0.5
-    - libibverbs-devel-cos6-x86_64 >=1.1
+    - libibcm-cos6-x86_64 ==1.0.5 *_{{ cdt_build_number|int + 1000 }}
+    - libibverbs-devel-cos6-x86_64 >=1.1 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libibcm-cos6-x86_64 ==1.0.5
-    - libibverbs-devel-cos6-x86_64 >=1.1
+    - libibcm-cos6-x86_64 ==1.0.5 *_{{ cdt_build_number|int + 1000 }}
+    - libibverbs-devel-cos6-x86_64 >=1.1 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libibcm-cos6-x86_64 ==1.0.5
-    - libibverbs-devel-cos6-x86_64 >=1.1
+    - libibcm-cos6-x86_64 ==1.0.5 *_{{ cdt_build_number|int + 1000 }}
+    - libibverbs-devel-cos6-x86_64 >=1.1 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libibverbs-cos6-x86_64/build.sh
+++ b/cdts/libibverbs-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libibverbs-devel-cos6-x86_64/build.sh
+++ b/cdts/libibverbs-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libibverbs-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libibverbs-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libibverbs-cos6-x86_64 ==1.1.8
+    - libibverbs-cos6-x86_64 ==1.1.8 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libibverbs-cos6-x86_64 ==1.1.8
+    - libibverbs-cos6-x86_64 ==1.1.8 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libibverbs-cos6-x86_64 ==1.1.8
+    - libibverbs-cos6-x86_64 ==1.1.8 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libnl-cos6-x86_64/build.sh
+++ b/cdts/libnl-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libnl-cos7-aarch64/build.sh
+++ b/cdts/libnl-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libnl-cos7-ppc64le/build.sh
+++ b/cdts/libnl-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libnl-cos7-x86_64/build.sh
+++ b/cdts/libnl-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libnl-devel-cos6-x86_64/build.sh
+++ b/cdts/libnl-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libnl-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libnl-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libnl-cos6-x86_64 ==1.1.4
+    - libnl-cos6-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libnl-cos6-x86_64 ==1.1.4
+    - libnl-cos6-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libnl-cos6-x86_64 ==1.1.4
+    - libnl-cos6-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libnl-devel-cos7-aarch64/build.sh
+++ b/cdts/libnl-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libnl-devel-cos7-aarch64/meta.yaml
+++ b/cdts/libnl-devel-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libnl-cos7-aarch64 ==1.1.4
+    - libnl-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libnl-cos7-aarch64 ==1.1.4
+    - libnl-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libnl-cos7-aarch64 ==1.1.4
+    - libnl-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libnl-devel-cos7-ppc64le/build.sh
+++ b/cdts/libnl-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libnl-devel-cos7-ppc64le/meta.yaml
+++ b/cdts/libnl-devel-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libnl-cos7-ppc64le ==1.1.4
+    - libnl-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libnl-cos7-ppc64le ==1.1.4
+    - libnl-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libnl-cos7-ppc64le ==1.1.4
+    - libnl-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libnl-devel-cos7-x86_64/build.sh
+++ b/cdts/libnl-devel-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libnl-devel-cos7-x86_64/meta.yaml
+++ b/cdts/libnl-devel-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libnl-cos7-x86_64 ==1.1.4
+    - libnl-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libnl-cos7-x86_64 ==1.1.4
+    - libnl-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libnl-cos7-x86_64 ==1.1.4
+    - libnl-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/librdmacm-cos6-x86_64/build.sh
+++ b/cdts/librdmacm-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/librdmacm-devel-cos6-x86_64/build.sh
+++ b/cdts/librdmacm-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/librdmacm-devel-cos6-x86_64/meta.yaml
+++ b/cdts/librdmacm-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - librdmacm-cos6-x86_64 ==1.0.21
+    - librdmacm-cos6-x86_64 ==1.0.21 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - librdmacm-cos6-x86_64 ==1.0.21
+    - librdmacm-cos6-x86_64 ==1.0.21 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - librdmacm-cos6-x86_64 ==1.0.21
+    - librdmacm-cos6-x86_64 ==1.0.21 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libselinux-cos6-x86_64/meta.yaml
+++ b/cdts/libselinux-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libsepol-cos6-x86_64 >=2.0.32
+    - libsepol-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libsepol-cos6-x86_64 >=2.0.32
+    - libsepol-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libsepol-cos6-x86_64 >=2.0.32
+    - libsepol-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libselinux-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libselinux-devel-cos6-x86_64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libselinux-cos6-x86_64 ==2.0.94
-    - libsepol-devel-cos6-x86_64 >=2.0.32
+    - libselinux-cos6-x86_64 ==2.0.94 *_{{ cdt_build_number|int + 1000 }}
+    - libsepol-devel-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libselinux-cos6-x86_64 ==2.0.94
-    - libsepol-devel-cos6-x86_64 >=2.0.32
+    - libselinux-cos6-x86_64 ==2.0.94 *_{{ cdt_build_number|int + 1000 }}
+    - libsepol-devel-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libselinux-cos6-x86_64 ==2.0.94
-    - libsepol-devel-cos6-x86_64 >=2.0.32
+    - libselinux-cos6-x86_64 ==2.0.94 *_{{ cdt_build_number|int + 1000 }}
+    - libsepol-devel-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libsepol-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libsepol-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libsepol-cos6-x86_64 ==2.0.41
+    - libsepol-cos6-x86_64 ==2.0.41 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libsepol-cos6-x86_64 ==2.0.41
+    - libsepol-cos6-x86_64 ==2.0.41 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libsepol-cos6-x86_64 ==2.0.41
+    - libsepol-cos6-x86_64 ==2.0.41 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libudev-cos6-x86_64/build.sh
+++ b/cdts/libudev-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libx11-cos6-x86_64/meta.yaml
+++ b/cdts/libx11-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-common-cos6-x86_64 ==1.6.4
+    - libx11-common-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-common-cos6-x86_64 ==1.6.4
+    - libx11-common-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libx11-common-cos6-x86_64 ==1.6.4
+    - libx11-common-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libx11-cos7-aarch64/meta.yaml
+++ b/cdts/libx11-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-common-cos7-aarch64 >=1.6.7
+    - libx11-common-cos7-aarch64 >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-common-cos7-aarch64 >=1.6.7
+    - libx11-common-cos7-aarch64 >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libx11-common-cos7-aarch64 >=1.6.7
+    - libx11-common-cos7-aarch64 >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libx11-cos7-ppc64le/meta.yaml
+++ b/cdts/libx11-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-common-cos7-ppc64le >=1.6.7
+    - libx11-common-cos7-ppc64le >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-common-cos7-ppc64le >=1.6.7
+    - libx11-common-cos7-ppc64le >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libx11-common-cos7-ppc64le >=1.6.7
+    - libx11-common-cos7-ppc64le >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libx11-cos7-x86_64/meta.yaml
+++ b/cdts/libx11-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-common-cos7-x86_64 >=1.6.7
+    - libx11-common-cos7-x86_64 >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-common-cos7-x86_64 >=1.6.7
+    - libx11-common-cos7-x86_64 >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libx11-common-cos7-x86_64 >=1.6.7
+    - libx11-common-cos7-x86_64 >=1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/libx11-devel-cos6-x86_64/build.sh
+++ b/cdts/libx11-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libx11-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libx11-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos6-x86_64 ==1.6.4
+    - libx11-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos6-x86_64 ==1.6.4
+    - libx11-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libx11-cos6-x86_64 ==1.6.4
+    - libx11-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libx11-devel-cos7-aarch64/build.sh
+++ b/cdts/libx11-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libx11-devel-cos7-aarch64/meta.yaml
+++ b/cdts/libx11-devel-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-aarch64 ==1.6.7
+    - libx11-cos7-aarch64 ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-aarch64 ==1.6.7
+    - libx11-cos7-aarch64 ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libx11-cos7-aarch64 ==1.6.7
+    - libx11-cos7-aarch64 ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libx11-devel-cos7-ppc64le/build.sh
+++ b/cdts/libx11-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libx11-devel-cos7-ppc64le/meta.yaml
+++ b/cdts/libx11-devel-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-ppc64le ==1.6.7
+    - libx11-cos7-ppc64le ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-ppc64le ==1.6.7
+    - libx11-cos7-ppc64le ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libx11-cos7-ppc64le ==1.6.7
+    - libx11-cos7-ppc64le ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libx11-devel-cos7-x86_64/build.sh
+++ b/cdts/libx11-devel-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/libx11-devel-cos7-x86_64/meta.yaml
+++ b/cdts/libx11-devel-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-x86_64 ==1.6.7
+    - libx11-cos7-x86_64 ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-x86_64 ==1.6.7
+    - libx11-cos7-x86_64 ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libx11-cos7-x86_64 ==1.6.7
+    - libx11-cos7-x86_64 ==1.6.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/libxdamage-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libxdamage-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxdamage-cos6-x86_64 ==1.1.3
+    - libxdamage-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxdamage-cos6-x86_64 ==1.1.3
+    - libxdamage-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libxdamage-cos6-x86_64 ==1.1.3
+    - libxdamage-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libxdamage-devel-cos7-aarch64/meta.yaml
+++ b/cdts/libxdamage-devel-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxdamage-cos7-aarch64 ==1.1.4
+    - libxdamage-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxdamage-cos7-aarch64 ==1.1.4
+    - libxdamage-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libxdamage-cos7-aarch64 ==1.1.4
+    - libxdamage-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libxdamage-devel-cos7-ppc64le/meta.yaml
+++ b/cdts/libxdamage-devel-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxdamage-cos7-ppc64le ==1.1.4
+    - libxdamage-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxdamage-cos7-ppc64le ==1.1.4
+    - libxdamage-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libxdamage-cos7-ppc64le ==1.1.4
+    - libxdamage-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libxdamage-devel-cos7-x86_64/meta.yaml
+++ b/cdts/libxdamage-devel-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxdamage-cos7-x86_64 ==1.1.4
+    - libxdamage-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxdamage-cos7-x86_64 ==1.1.4
+    - libxdamage-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libxdamage-cos7-x86_64 ==1.1.4
+    - libxdamage-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/libxext-cos6-x86_64/meta.yaml
+++ b/cdts/libxext-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libxext-cos7-aarch64/meta.yaml
+++ b/cdts/libxext-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libxext-cos7-ppc64le/meta.yaml
+++ b/cdts/libxext-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libxext-cos7-x86_64/meta.yaml
+++ b/cdts/libxext-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-x86_64 >=1.5.99.902
+    - libx11-cos7-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-x86_64 >=1.5.99.902
+    - libx11-cos7-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libx11-cos7-x86_64 >=1.5.99.902
+    - libx11-cos7-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/libxext-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libxext-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxext-cos6-x86_64 ==1.3.3
+    - libxext-cos6-x86_64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxext-cos6-x86_64 ==1.3.3
+    - libxext-cos6-x86_64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libxext-cos6-x86_64 ==1.3.3
+    - libxext-cos6-x86_64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libxext-devel-cos7-aarch64/meta.yaml
+++ b/cdts/libxext-devel-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxext-cos7-aarch64 ==1.3.3
+    - libxext-cos7-aarch64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxext-cos7-aarch64 ==1.3.3
+    - libxext-cos7-aarch64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libxext-cos7-aarch64 ==1.3.3
+    - libxext-cos7-aarch64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libxext-devel-cos7-ppc64le/meta.yaml
+++ b/cdts/libxext-devel-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxext-cos7-ppc64le ==1.3.3
+    - libxext-cos7-ppc64le ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxext-cos7-ppc64le ==1.3.3
+    - libxext-cos7-ppc64le ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libxext-cos7-ppc64le ==1.3.3
+    - libxext-cos7-ppc64le ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libxext-devel-cos7-x86_64/meta.yaml
+++ b/cdts/libxext-devel-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxext-cos7-x86_64 ==1.3.3
+    - libxext-cos7-x86_64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxext-cos7-x86_64 ==1.3.3
+    - libxext-cos7-x86_64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libxext-cos7-x86_64 ==1.3.3
+    - libxext-cos7-x86_64 ==1.3.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/libxxf86vm-cos6-x86_64/meta.yaml
+++ b/cdts/libxxf86vm-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libxxf86vm-cos7-aarch64/meta.yaml
+++ b/cdts/libxxf86vm-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libxxf86vm-cos7-ppc64le/meta.yaml
+++ b/cdts/libxxf86vm-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libxxf86vm-cos7-x86_64/meta.yaml
+++ b/cdts/libxxf86vm-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-x86_64 >=1.5.99.902
+    - libx11-cos7-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos7-x86_64 >=1.5.99.902
+    - libx11-cos7-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libx11-cos7-x86_64 >=1.5.99.902
+    - libx11-cos7-x86_64 >=1.5.99.902 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/libxxf86vm-devel-cos6-x86_64/meta.yaml
+++ b/cdts/libxxf86vm-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxxf86vm-cos6-x86_64 ==1.1.3
+    - libxxf86vm-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxxf86vm-cos6-x86_64 ==1.1.3
+    - libxxf86vm-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libxxf86vm-cos6-x86_64 ==1.1.3
+    - libxxf86vm-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/libxxf86vm-devel-cos7-aarch64/meta.yaml
+++ b/cdts/libxxf86vm-devel-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxxf86vm-cos7-aarch64 ==1.1.4
+    - libxxf86vm-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxxf86vm-cos7-aarch64 ==1.1.4
+    - libxxf86vm-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libxxf86vm-cos7-aarch64 ==1.1.4
+    - libxxf86vm-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/libxxf86vm-devel-cos7-ppc64le/meta.yaml
+++ b/cdts/libxxf86vm-devel-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxxf86vm-cos7-ppc64le ==1.1.4
+    - libxxf86vm-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxxf86vm-cos7-ppc64le ==1.1.4
+    - libxxf86vm-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libxxf86vm-cos7-ppc64le ==1.1.4
+    - libxxf86vm-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/libxxf86vm-devel-cos7-x86_64/meta.yaml
+++ b/cdts/libxxf86vm-devel-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libxxf86vm-cos7-x86_64 ==1.1.4
+    - libxxf86vm-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libxxf86vm-cos7-x86_64 ==1.1.4
+    - libxxf86vm-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libxxf86vm-cos7-x86_64 ==1.1.4
+    - libxxf86vm-cos7-x86_64 ==1.1.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/mesa-dri-drivers-cos6-x86_64/build.sh
+++ b/cdts/mesa-dri-drivers-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-dri-drivers-cos6-x86_64/meta.yaml
+++ b/cdts/mesa-dri-drivers-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-dri1-drivers-cos6-x86_64 >=7.11
+    - mesa-dri1-drivers-cos6-x86_64 >=7.11 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-dri1-drivers-cos6-x86_64 >=7.11
+    - mesa-dri1-drivers-cos6-x86_64 >=7.11 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - mesa-dri1-drivers-cos6-x86_64 >=7.11
+    - mesa-dri1-drivers-cos6-x86_64 >=7.11 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/mesa-dri-drivers-cos7-aarch64/build.sh
+++ b/cdts/mesa-dri-drivers-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-dri-drivers-cos7-aarch64/meta.yaml
+++ b/cdts/mesa-dri-drivers-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-aarch64 >=2.4.83
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-aarch64 >=2.4.83
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libdrm-cos7-aarch64 >=2.4.83
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/mesa-dri-drivers-cos7-ppc64le/build.sh
+++ b/cdts/mesa-dri-drivers-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-dri-drivers-cos7-ppc64le/meta.yaml
+++ b/cdts/mesa-dri-drivers-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-ppc64le >=2.4.83
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-ppc64le >=2.4.83
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libdrm-cos7-ppc64le >=2.4.83
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/mesa-dri-drivers-cos7-x86_64/build.sh
+++ b/cdts/mesa-dri-drivers-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-dri-drivers-cos7-x86_64/meta.yaml
+++ b/cdts/mesa-dri-drivers-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-x86_64 >=2.4.83
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-x86_64 >=2.4.83
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libdrm-cos7-x86_64 >=2.4.83
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/mesa-dri1-drivers-cos6-x86_64/build.sh
+++ b/cdts/mesa-dri1-drivers-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-khr-devel-cos7-aarch64/build.sh
+++ b/cdts/mesa-khr-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-khr-devel-cos7-ppc64le/build.sh
+++ b/cdts/mesa-khr-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-khr-devel-cos7-x86_64/build.sh
+++ b/cdts/mesa-khr-devel-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-cos6-x86_64/build.sh
+++ b/cdts/mesa-libegl-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-cos7-aarch64/build.sh
+++ b/cdts/mesa-libegl-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-cos7-aarch64/meta.yaml
+++ b/cdts/mesa-libegl-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libgbm-cos7-aarch64 ==18.3.4
+    - mesa-libgbm-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libgbm-cos7-aarch64 ==18.3.4
+    - mesa-libgbm-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - mesa-libgbm-cos7-aarch64 ==18.3.4
+    - mesa-libgbm-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/mesa-libegl-cos7-ppc64le/build.sh
+++ b/cdts/mesa-libegl-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-cos7-ppc64le/meta.yaml
+++ b/cdts/mesa-libegl-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libgbm-cos7-ppc64le ==18.3.4
+    - mesa-libgbm-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libgbm-cos7-ppc64le ==18.3.4
+    - mesa-libgbm-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - mesa-libgbm-cos7-ppc64le ==18.3.4
+    - mesa-libgbm-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/mesa-libegl-cos7-x86_64/build.sh
+++ b/cdts/mesa-libegl-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-cos7-x86_64/meta.yaml
+++ b/cdts/mesa-libegl-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libgbm-cos7-x86_64 ==18.3.4
+    - mesa-libgbm-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libgbm-cos7-x86_64 ==18.3.4
+    - mesa-libgbm-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - mesa-libgbm-cos7-x86_64 ==18.3.4
+    - mesa-libgbm-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/mesa-libegl-devel-cos6-x86_64/build.sh
+++ b/cdts/mesa-libegl-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-devel-cos6-x86_64/meta.yaml
+++ b/cdts/mesa-libegl-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libegl-cos6-x86_64 ==11.0.7
+    - mesa-libegl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libegl-cos6-x86_64 ==11.0.7
+    - mesa-libegl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - mesa-libegl-cos6-x86_64 ==11.0.7
+    - mesa-libegl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/mesa-libegl-devel-cos7-aarch64/build.sh
+++ b/cdts/mesa-libegl-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-devel-cos7-aarch64/meta.yaml
+++ b/cdts/mesa-libegl-devel-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libegl-cos7-aarch64 ==18.3.4
+    - mesa-libegl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libegl-cos7-aarch64 ==18.3.4
+    - mesa-libegl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - mesa-libegl-cos7-aarch64 ==18.3.4
+    - mesa-libegl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/mesa-libegl-devel-cos7-ppc64le/build.sh
+++ b/cdts/mesa-libegl-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-devel-cos7-ppc64le/meta.yaml
+++ b/cdts/mesa-libegl-devel-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libegl-cos7-ppc64le ==18.3.4
+    - mesa-libegl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libegl-cos7-ppc64le ==18.3.4
+    - mesa-libegl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - mesa-libegl-cos7-ppc64le ==18.3.4
+    - mesa-libegl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/mesa-libegl-devel-cos7-x86_64/build.sh
+++ b/cdts/mesa-libegl-devel-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libegl-devel-cos7-x86_64/meta.yaml
+++ b/cdts/mesa-libegl-devel-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libegl-cos7-x86_64 ==18.3.4
+    - mesa-libegl-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libegl-cos7-x86_64 ==18.3.4
+    - mesa-libegl-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - mesa-libegl-cos7-x86_64 ==18.3.4
+    - mesa-libegl-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/mesa-libgbm-cos6-x86_64/build.sh
+++ b/cdts/mesa-libgbm-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libgbm-cos7-aarch64/build.sh
+++ b/cdts/mesa-libgbm-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libgbm-cos7-aarch64/meta.yaml
+++ b/cdts/mesa-libgbm-cos7-aarch64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/mesa-libgbm-cos7-ppc64le/build.sh
+++ b/cdts/mesa-libgbm-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libgbm-cos7-ppc64le/meta.yaml
+++ b/cdts/mesa-libgbm-cos7-ppc64le/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/mesa-libgbm-cos7-x86_64/build.sh
+++ b/cdts/mesa-libgbm-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libgbm-cos7-x86_64/meta.yaml
+++ b/cdts/mesa-libgbm-cos7-x86_64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-x86_64 >=2.4.83
-    - mesa-libglapi-cos7-x86_64 ==18.3.4
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-x86_64 >=2.4.83
-    - mesa-libglapi-cos7-x86_64 ==18.3.4
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libdrm-cos7-x86_64 >=2.4.83
-    - mesa-libglapi-cos7-x86_64 ==18.3.4
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/mesa-libgl-cos6-x86_64/meta.yaml
+++ b/cdts/mesa-libgl-cos6-x86_64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libx11-cos6-x86_64 >1.6
-    - libdrm-cos6-x86_64 >=2.4.24
+    - libx11-cos6-x86_64 >1.6 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos6-x86_64 >=2.4.24 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libx11-cos6-x86_64 >1.6
-    - libdrm-cos6-x86_64 >=2.4.24
+    - libx11-cos6-x86_64 >1.6 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos6-x86_64 >=2.4.24 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - libx11-cos6-x86_64 >1.6
-    - libdrm-cos6-x86_64 >=2.4.24
+    - libx11-cos6-x86_64 >1.6 *_{{ cdt_build_number|int + 1000 }}
+    - libdrm-cos6-x86_64 >=2.4.24 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/mesa-libgl-cos7-aarch64/meta.yaml
+++ b/cdts/mesa-libgl-cos7-aarch64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/mesa-libgl-cos7-ppc64le/meta.yaml
+++ b/cdts/mesa-libgl-cos7-ppc64le/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/mesa-libgl-cos7-x86_64/meta.yaml
+++ b/cdts/mesa-libgl-cos7-x86_64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-x86_64 >=2.4.83
-    - mesa-libglapi-cos7-x86_64 ==18.3.4
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - libdrm-cos7-x86_64 >=2.4.83
-    - mesa-libglapi-cos7-x86_64 ==18.3.4
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - libdrm-cos7-x86_64 >=2.4.83
-    - mesa-libglapi-cos7-x86_64 ==18.3.4
+    - libdrm-cos7-x86_64 >=2.4.83 *_{{ cdt_build_number|int + 1000 }}
+    - mesa-libglapi-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/mesa-libgl-devel-cos6-x86_64/build.sh
+++ b/cdts/mesa-libgl-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libgl-devel-cos6-x86_64/meta.yaml
+++ b/cdts/mesa-libgl-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libgl-cos6-x86_64 ==11.0.7
+    - mesa-libgl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libgl-cos6-x86_64 ==11.0.7
+    - mesa-libgl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - mesa-libgl-cos6-x86_64 ==11.0.7
+    - mesa-libgl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/cdts/mesa-libgl-devel-cos7-aarch64/build.sh
+++ b/cdts/mesa-libgl-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libgl-devel-cos7-aarch64/meta.yaml
+++ b/cdts/mesa-libgl-devel-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libgl-cos7-aarch64 ==18.3.4
+    - mesa-libgl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libgl-cos7-aarch64 ==18.3.4
+    - mesa-libgl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - mesa-libgl-cos7-aarch64 ==18.3.4
+    - mesa-libgl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/mesa-libgl-devel-cos7-ppc64le/build.sh
+++ b/cdts/mesa-libgl-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libgl-devel-cos7-ppc64le/meta.yaml
+++ b/cdts/mesa-libgl-devel-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libgl-cos7-ppc64le ==18.3.4
+    - mesa-libgl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libgl-cos7-ppc64le ==18.3.4
+    - mesa-libgl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - mesa-libgl-cos7-ppc64le ==18.3.4
+    - mesa-libgl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/mesa-libgl-devel-cos7-x86_64/build.sh
+++ b/cdts/mesa-libgl-devel-cos7-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/mesa-libgl-devel-cos7-x86_64/meta.yaml
+++ b/cdts/mesa-libgl-devel-cos7-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - mesa-libgl-cos7-x86_64 ==18.3.4
+    - mesa-libgl-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - mesa-libgl-cos7-x86_64 ==18.3.4
+    - mesa-libgl-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
   run:
-    - mesa-libgl-cos7-x86_64 ==18.3.4
+    - mesa-libgl-cos7-x86_64 ==18.3.4 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.17.*
 
 about:

--- a/cdts/nspr-cos7-aarch64/build.sh
+++ b/cdts/nspr-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nspr-cos7-ppc64le/build.sh
+++ b/cdts/nspr-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-cos7-aarch64/build.sh
+++ b/cdts/nss-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-cos7-aarch64/meta.yaml
+++ b/cdts/nss-cos7-aarch64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/nss-cos7-ppc64le/build.sh
+++ b/cdts/nss-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-cos7-ppc64le/meta.yaml
+++ b/cdts/nss-cos7-ppc64le/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/nss-softokn-cos7-aarch64/build.sh
+++ b/cdts/nss-softokn-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-softokn-cos7-aarch64/meta.yaml
+++ b/cdts/nss-softokn-cos7-aarch64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/nss-softokn-cos7-ppc64le/build.sh
+++ b/cdts/nss-softokn-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-softokn-cos7-ppc64le/meta.yaml
+++ b/cdts/nss-softokn-cos7-ppc64le/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/nss-softokn-freebl-cos7-aarch64/build.sh
+++ b/cdts/nss-softokn-freebl-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-softokn-freebl-cos7-aarch64/meta.yaml
+++ b/cdts/nss-softokn-freebl-cos7-aarch64/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/nss-softokn-freebl-cos7-ppc64le/build.sh
+++ b/cdts/nss-softokn-freebl-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-softokn-freebl-cos7-ppc64le/meta.yaml
+++ b/cdts/nss-softokn-freebl-cos7-ppc64le/meta.yaml
@@ -19,15 +19,15 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/nss-util-cos7-aarch64/build.sh
+++ b/cdts/nss-util-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-util-cos7-aarch64/meta.yaml
+++ b/cdts/nss-util-cos7-aarch64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-aarch64 >=4.21.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - nspr-cos7-aarch64 >=4.21.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
   run:
-    - nspr-cos7-aarch64 >=4.21.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-aarch64 2.17.*
 
 about:

--- a/cdts/nss-util-cos7-ppc64le/build.sh
+++ b/cdts/nss-util-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/nss-util-cos7-ppc64le/meta.yaml
+++ b/cdts/nss-util-cos7-ppc64le/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-ppc64le >=4.21.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - nspr-cos7-ppc64le >=4.21.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
   run:
-    - nspr-cos7-ppc64le >=4.21.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-ppc64le 2.17.*
 
 about:

--- a/cdts/numactl-cos6-x86_64/build.sh
+++ b/cdts/numactl-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/numactl-devel-cos6-x86_64/build.sh
+++ b/cdts/numactl-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/cdts/numactl-devel-cos6-x86_64/meta.yaml
+++ b/cdts/numactl-devel-cos6-x86_64/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - numactl-cos6-x86_64 ==2.0.9
+    - numactl-cos6-x86_64 ==2.0.9 *_{{ cdt_build_number|int + 1000 }}
   host:
-    - numactl-cos6-x86_64 ==2.0.9
+    - numactl-cos6-x86_64 ==2.0.9 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
   run:
-    - numactl-cos6-x86_64 ==2.0.9
+    - numactl-cos6-x86_64 ==2.0.9 *_{{ cdt_build_number|int + 1000 }}
     - sysroot_linux-64 2.12.*
 
 about:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,2 +1,2 @@
 cdt_build_number:
-  - "101"
+  - "102"

--- a/legacy_cdts/chkconfig-cos6-x86_64/build.sh
+++ b/legacy_cdts/chkconfig-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/chkconfig-cos7-aarch64/build.sh
+++ b/legacy_cdts/chkconfig-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/chkconfig-cos7-ppc64le/build.sh
+++ b/legacy_cdts/chkconfig-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/kernel-headers-cos6-x86_64/build.sh
+++ b/legacy_cdts/kernel-headers-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/kernel-headers-cos7-aarch64/build.sh
+++ b/legacy_cdts/kernel-headers-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/kernel-headers-cos7-ppc64le/build.sh
+++ b/legacy_cdts/kernel-headers-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libdrm-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/libdrm-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libdrm-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libdrm-devel-cos6-x86_64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - kernel-headers-cos6-x86_64 >=2.6.27
-    - libdrm-cos6-x86_64 ==2.4.65
+    - kernel-headers-cos6-x86_64 >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos6-x86_64 ==2.4.65 *_{{ cdt_build_number }}
   host:
-    - kernel-headers-cos6-x86_64 >=2.6.27
-    - libdrm-cos6-x86_64 ==2.4.65
+    - kernel-headers-cos6-x86_64 >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos6-x86_64 ==2.4.65 *_{{ cdt_build_number }}
   run:
-    - kernel-headers-cos6-x86_64 >=2.6.27
-    - libdrm-cos6-x86_64 ==2.4.65
+    - kernel-headers-cos6-x86_64 >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos6-x86_64 ==2.4.65 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libdrm-devel-cos7-aarch64/build.sh
+++ b/legacy_cdts/libdrm-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libdrm-devel-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libdrm-devel-cos7-aarch64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - kernel-headers-cos7-aarch64 >=2.6.27
-    - libdrm-cos7-aarch64 ==2.4.97
+    - kernel-headers-cos7-aarch64 >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos7-aarch64 ==2.4.97 *_{{ cdt_build_number }}
   host:
-    - kernel-headers-cos7-aarch64 >=2.6.27
-    - libdrm-cos7-aarch64 ==2.4.97
+    - kernel-headers-cos7-aarch64 >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos7-aarch64 ==2.4.97 *_{{ cdt_build_number }}
   run:
-    - kernel-headers-cos7-aarch64 >=2.6.27
-    - libdrm-cos7-aarch64 ==2.4.97
+    - kernel-headers-cos7-aarch64 >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos7-aarch64 ==2.4.97 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libdrm-devel-cos7-ppc64le/build.sh
+++ b/legacy_cdts/libdrm-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libdrm-devel-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libdrm-devel-cos7-ppc64le/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - kernel-headers-cos7-ppc64le >=2.6.27
-    - libdrm-cos7-ppc64le ==2.4.97
+    - kernel-headers-cos7-ppc64le >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos7-ppc64le ==2.4.97 *_{{ cdt_build_number }}
   host:
-    - kernel-headers-cos7-ppc64le >=2.6.27
-    - libdrm-cos7-ppc64le ==2.4.97
+    - kernel-headers-cos7-ppc64le >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos7-ppc64le ==2.4.97 *_{{ cdt_build_number }}
   run:
-    - kernel-headers-cos7-ppc64le >=2.6.27
-    - libdrm-cos7-ppc64le ==2.4.97
+    - kernel-headers-cos7-ppc64le >=2.6.27 *_{{ cdt_build_number }}
+    - libdrm-cos7-ppc64le ==2.4.97 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/libibcm-cos6-x86_64/build.sh
+++ b/legacy_cdts/libibcm-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libibcm-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/libibcm-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libibcm-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libibcm-devel-cos6-x86_64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - libibcm-cos6-x86_64 ==1.0.5
-    - libibverbs-devel-cos6-x86_64 >=1.1
+    - libibcm-cos6-x86_64 ==1.0.5 *_{{ cdt_build_number }}
+    - libibverbs-devel-cos6-x86_64 >=1.1 *_{{ cdt_build_number }}
   host:
-    - libibcm-cos6-x86_64 ==1.0.5
-    - libibverbs-devel-cos6-x86_64 >=1.1
+    - libibcm-cos6-x86_64 ==1.0.5 *_{{ cdt_build_number }}
+    - libibverbs-devel-cos6-x86_64 >=1.1 *_{{ cdt_build_number }}
   run:
-    - libibcm-cos6-x86_64 ==1.0.5
-    - libibverbs-devel-cos6-x86_64 >=1.1
+    - libibcm-cos6-x86_64 ==1.0.5 *_{{ cdt_build_number }}
+    - libibverbs-devel-cos6-x86_64 >=1.1 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libibverbs-cos6-x86_64/build.sh
+++ b/legacy_cdts/libibverbs-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libibverbs-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/libibverbs-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libibverbs-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libibverbs-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libibverbs-cos6-x86_64 ==1.1.8
+    - libibverbs-cos6-x86_64 ==1.1.8 *_{{ cdt_build_number }}
   host:
-    - libibverbs-cos6-x86_64 ==1.1.8
+    - libibverbs-cos6-x86_64 ==1.1.8 *_{{ cdt_build_number }}
   run:
-    - libibverbs-cos6-x86_64 ==1.1.8
+    - libibverbs-cos6-x86_64 ==1.1.8 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libnl-cos6-x86_64/build.sh
+++ b/legacy_cdts/libnl-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libnl-cos7-aarch64/build.sh
+++ b/legacy_cdts/libnl-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libnl-cos7-ppc64le/build.sh
+++ b/legacy_cdts/libnl-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libnl-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/libnl-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libnl-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libnl-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libnl-cos6-x86_64 ==1.1.4
+    - libnl-cos6-x86_64 ==1.1.4 *_{{ cdt_build_number }}
   host:
-    - libnl-cos6-x86_64 ==1.1.4
+    - libnl-cos6-x86_64 ==1.1.4 *_{{ cdt_build_number }}
   run:
-    - libnl-cos6-x86_64 ==1.1.4
+    - libnl-cos6-x86_64 ==1.1.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libnl-devel-cos7-aarch64/build.sh
+++ b/legacy_cdts/libnl-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libnl-devel-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libnl-devel-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libnl-cos7-aarch64 ==1.1.4
+    - libnl-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   host:
-    - libnl-cos7-aarch64 ==1.1.4
+    - libnl-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   run:
-    - libnl-cos7-aarch64 ==1.1.4
+    - libnl-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libnl-devel-cos7-ppc64le/build.sh
+++ b/legacy_cdts/libnl-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libnl-devel-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libnl-devel-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libnl-cos7-ppc64le ==1.1.4
+    - libnl-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   host:
-    - libnl-cos7-ppc64le ==1.1.4
+    - libnl-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   run:
-    - libnl-cos7-ppc64le ==1.1.4
+    - libnl-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/librdmacm-cos6-x86_64/build.sh
+++ b/legacy_cdts/librdmacm-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/librdmacm-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/librdmacm-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/librdmacm-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/librdmacm-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - librdmacm-cos6-x86_64 ==1.0.21
+    - librdmacm-cos6-x86_64 ==1.0.21 *_{{ cdt_build_number }}
   host:
-    - librdmacm-cos6-x86_64 ==1.0.21
+    - librdmacm-cos6-x86_64 ==1.0.21 *_{{ cdt_build_number }}
   run:
-    - librdmacm-cos6-x86_64 ==1.0.21
+    - librdmacm-cos6-x86_64 ==1.0.21 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libselinux-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libselinux-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libsepol-cos6-x86_64 >=2.0.32
+    - libsepol-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number }}
   host:
-    - libsepol-cos6-x86_64 >=2.0.32
+    - libsepol-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number }}
   run:
-    - libsepol-cos6-x86_64 >=2.0.32
+    - libsepol-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libselinux-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libselinux-devel-cos6-x86_64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - libselinux-cos6-x86_64 ==2.0.94
-    - libsepol-devel-cos6-x86_64 >=2.0.32
+    - libselinux-cos6-x86_64 ==2.0.94 *_{{ cdt_build_number }}
+    - libsepol-devel-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number }}
   host:
-    - libselinux-cos6-x86_64 ==2.0.94
-    - libsepol-devel-cos6-x86_64 >=2.0.32
+    - libselinux-cos6-x86_64 ==2.0.94 *_{{ cdt_build_number }}
+    - libsepol-devel-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number }}
   run:
-    - libselinux-cos6-x86_64 ==2.0.94
-    - libsepol-devel-cos6-x86_64 >=2.0.32
+    - libselinux-cos6-x86_64 ==2.0.94 *_{{ cdt_build_number }}
+    - libsepol-devel-cos6-x86_64 >=2.0.32 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libsepol-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libsepol-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libsepol-cos6-x86_64 ==2.0.41
+    - libsepol-cos6-x86_64 ==2.0.41 *_{{ cdt_build_number }}
   host:
-    - libsepol-cos6-x86_64 ==2.0.41
+    - libsepol-cos6-x86_64 ==2.0.41 *_{{ cdt_build_number }}
   run:
-    - libsepol-cos6-x86_64 ==2.0.41
+    - libsepol-cos6-x86_64 ==2.0.41 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libudev-cos6-x86_64/build.sh
+++ b/legacy_cdts/libudev-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libx11-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libx11-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-common-cos6-x86_64 ==1.6.4
+    - libx11-common-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number }}
   host:
-    - libx11-common-cos6-x86_64 ==1.6.4
+    - libx11-common-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number }}
   run:
-    - libx11-common-cos6-x86_64 ==1.6.4
+    - libx11-common-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libx11-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libx11-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-common-cos7-aarch64 >=1.6.7
+    - libx11-common-cos7-aarch64 >=1.6.7 *_{{ cdt_build_number }}
   host:
-    - libx11-common-cos7-aarch64 >=1.6.7
+    - libx11-common-cos7-aarch64 >=1.6.7 *_{{ cdt_build_number }}
   run:
-    - libx11-common-cos7-aarch64 >=1.6.7
+    - libx11-common-cos7-aarch64 >=1.6.7 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libx11-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libx11-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-common-cos7-ppc64le >=1.6.7
+    - libx11-common-cos7-ppc64le >=1.6.7 *_{{ cdt_build_number }}
   host:
-    - libx11-common-cos7-ppc64le >=1.6.7
+    - libx11-common-cos7-ppc64le >=1.6.7 *_{{ cdt_build_number }}
   run:
-    - libx11-common-cos7-ppc64le >=1.6.7
+    - libx11-common-cos7-ppc64le >=1.6.7 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/libx11-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/libx11-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libx11-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libx11-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos6-x86_64 ==1.6.4
+    - libx11-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number }}
   host:
-    - libx11-cos6-x86_64 ==1.6.4
+    - libx11-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number }}
   run:
-    - libx11-cos6-x86_64 ==1.6.4
+    - libx11-cos6-x86_64 ==1.6.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libx11-devel-cos7-aarch64/build.sh
+++ b/legacy_cdts/libx11-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libx11-devel-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libx11-devel-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-aarch64 ==1.6.7
+    - libx11-cos7-aarch64 ==1.6.7 *_{{ cdt_build_number }}
   host:
-    - libx11-cos7-aarch64 ==1.6.7
+    - libx11-cos7-aarch64 ==1.6.7 *_{{ cdt_build_number }}
   run:
-    - libx11-cos7-aarch64 ==1.6.7
+    - libx11-cos7-aarch64 ==1.6.7 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libx11-devel-cos7-ppc64le/build.sh
+++ b/legacy_cdts/libx11-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/libx11-devel-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libx11-devel-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-ppc64le ==1.6.7
+    - libx11-cos7-ppc64le ==1.6.7 *_{{ cdt_build_number }}
   host:
-    - libx11-cos7-ppc64le ==1.6.7
+    - libx11-cos7-ppc64le ==1.6.7 *_{{ cdt_build_number }}
   run:
-    - libx11-cos7-ppc64le ==1.6.7
+    - libx11-cos7-ppc64le ==1.6.7 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/libxdamage-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libxdamage-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxdamage-cos6-x86_64 ==1.1.3
+    - libxdamage-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number }}
   host:
-    - libxdamage-cos6-x86_64 ==1.1.3
+    - libxdamage-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number }}
   run:
-    - libxdamage-cos6-x86_64 ==1.1.3
+    - libxdamage-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libxdamage-devel-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libxdamage-devel-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxdamage-cos7-aarch64 ==1.1.4
+    - libxdamage-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   host:
-    - libxdamage-cos7-aarch64 ==1.1.4
+    - libxdamage-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   run:
-    - libxdamage-cos7-aarch64 ==1.1.4
+    - libxdamage-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libxdamage-devel-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libxdamage-devel-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxdamage-cos7-ppc64le ==1.1.4
+    - libxdamage-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   host:
-    - libxdamage-cos7-ppc64le ==1.1.4
+    - libxdamage-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   run:
-    - libxdamage-cos7-ppc64le ==1.1.4
+    - libxdamage-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/libxext-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libxext-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number }}
   host:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number }}
   run:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libxext-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libxext-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number }}
   host:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number }}
   run:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libxext-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libxext-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number }}
   host:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number }}
   run:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/libxext-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libxext-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxext-cos6-x86_64 ==1.3.3
+    - libxext-cos6-x86_64 ==1.3.3 *_{{ cdt_build_number }}
   host:
-    - libxext-cos6-x86_64 ==1.3.3
+    - libxext-cos6-x86_64 ==1.3.3 *_{{ cdt_build_number }}
   run:
-    - libxext-cos6-x86_64 ==1.3.3
+    - libxext-cos6-x86_64 ==1.3.3 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libxext-devel-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libxext-devel-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxext-cos7-aarch64 ==1.3.3
+    - libxext-cos7-aarch64 ==1.3.3 *_{{ cdt_build_number }}
   host:
-    - libxext-cos7-aarch64 ==1.3.3
+    - libxext-cos7-aarch64 ==1.3.3 *_{{ cdt_build_number }}
   run:
-    - libxext-cos7-aarch64 ==1.3.3
+    - libxext-cos7-aarch64 ==1.3.3 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libxext-devel-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libxext-devel-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxext-cos7-ppc64le ==1.3.3
+    - libxext-cos7-ppc64le ==1.3.3 *_{{ cdt_build_number }}
   host:
-    - libxext-cos7-ppc64le ==1.3.3
+    - libxext-cos7-ppc64le ==1.3.3 *_{{ cdt_build_number }}
   run:
-    - libxext-cos7-ppc64le ==1.3.3
+    - libxext-cos7-ppc64le ==1.3.3 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/libxxf86vm-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libxxf86vm-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number }}
   host:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number }}
   run:
-    - libx11-cos6-x86_64 >=1.5.99.902
+    - libx11-cos6-x86_64 >=1.5.99.902 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libxxf86vm-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libxxf86vm-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number }}
   host:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number }}
   run:
-    - libx11-cos7-aarch64 >=1.5.99.902
+    - libx11-cos7-aarch64 >=1.5.99.902 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libxxf86vm-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libxxf86vm-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number }}
   host:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number }}
   run:
-    - libx11-cos7-ppc64le >=1.5.99.902
+    - libx11-cos7-ppc64le >=1.5.99.902 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/libxxf86vm-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/libxxf86vm-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxxf86vm-cos6-x86_64 ==1.1.3
+    - libxxf86vm-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number }}
   host:
-    - libxxf86vm-cos6-x86_64 ==1.1.3
+    - libxxf86vm-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number }}
   run:
-    - libxxf86vm-cos6-x86_64 ==1.1.3
+    - libxxf86vm-cos6-x86_64 ==1.1.3 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/libxxf86vm-devel-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/libxxf86vm-devel-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxxf86vm-cos7-aarch64 ==1.1.4
+    - libxxf86vm-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   host:
-    - libxxf86vm-cos7-aarch64 ==1.1.4
+    - libxxf86vm-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   run:
-    - libxxf86vm-cos7-aarch64 ==1.1.4
+    - libxxf86vm-cos7-aarch64 ==1.1.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/libxxf86vm-devel-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/libxxf86vm-devel-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libxxf86vm-cos7-ppc64le ==1.1.4
+    - libxxf86vm-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   host:
-    - libxxf86vm-cos7-ppc64le ==1.1.4
+    - libxxf86vm-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   run:
-    - libxxf86vm-cos7-ppc64le ==1.1.4
+    - libxxf86vm-cos7-ppc64le ==1.1.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/mesa-dri-drivers-cos6-x86_64/build.sh
+++ b/legacy_cdts/mesa-dri-drivers-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-dri-drivers-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/mesa-dri-drivers-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-dri1-drivers-cos6-x86_64 >=7.11
+    - mesa-dri1-drivers-cos6-x86_64 >=7.11 *_{{ cdt_build_number }}
   host:
-    - mesa-dri1-drivers-cos6-x86_64 >=7.11
+    - mesa-dri1-drivers-cos6-x86_64 >=7.11 *_{{ cdt_build_number }}
   run:
-    - mesa-dri1-drivers-cos6-x86_64 >=7.11
+    - mesa-dri1-drivers-cos6-x86_64 >=7.11 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/mesa-dri-drivers-cos7-aarch64/build.sh
+++ b/legacy_cdts/mesa-dri-drivers-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-dri-drivers-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/mesa-dri-drivers-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-aarch64 >=2.4.83
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
   host:
-    - libdrm-cos7-aarch64 >=2.4.83
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
   run:
-    - libdrm-cos7-aarch64 >=2.4.83
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/mesa-dri-drivers-cos7-ppc64le/build.sh
+++ b/legacy_cdts/mesa-dri-drivers-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-dri-drivers-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/mesa-dri-drivers-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-ppc64le >=2.4.83
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
   host:
-    - libdrm-cos7-ppc64le >=2.4.83
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
   run:
-    - libdrm-cos7-ppc64le >=2.4.83
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/mesa-dri1-drivers-cos6-x86_64/build.sh
+++ b/legacy_cdts/mesa-dri1-drivers-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-khr-devel-cos7-aarch64/build.sh
+++ b/legacy_cdts/mesa-khr-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-khr-devel-cos7-ppc64le/build.sh
+++ b/legacy_cdts/mesa-khr-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libegl-cos6-x86_64/build.sh
+++ b/legacy_cdts/mesa-libegl-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libegl-cos7-aarch64/build.sh
+++ b/legacy_cdts/mesa-libegl-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libegl-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/mesa-libegl-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-libgbm-cos7-aarch64 ==18.3.4
+    - mesa-libgbm-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - mesa-libgbm-cos7-aarch64 ==18.3.4
+    - mesa-libgbm-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - mesa-libgbm-cos7-aarch64 ==18.3.4
+    - mesa-libgbm-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/mesa-libegl-cos7-ppc64le/build.sh
+++ b/legacy_cdts/mesa-libegl-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libegl-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/mesa-libegl-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-libgbm-cos7-ppc64le ==18.3.4
+    - mesa-libgbm-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - mesa-libgbm-cos7-ppc64le ==18.3.4
+    - mesa-libgbm-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - mesa-libgbm-cos7-ppc64le ==18.3.4
+    - mesa-libgbm-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/mesa-libegl-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/mesa-libegl-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libegl-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/mesa-libegl-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-libegl-cos6-x86_64 ==11.0.7
+    - mesa-libegl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number }}
   host:
-    - mesa-libegl-cos6-x86_64 ==11.0.7
+    - mesa-libegl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number }}
   run:
-    - mesa-libegl-cos6-x86_64 ==11.0.7
+    - mesa-libegl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/mesa-libegl-devel-cos7-aarch64/build.sh
+++ b/legacy_cdts/mesa-libegl-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libegl-devel-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/mesa-libegl-devel-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-libegl-cos7-aarch64 ==18.3.4
+    - mesa-libegl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - mesa-libegl-cos7-aarch64 ==18.3.4
+    - mesa-libegl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - mesa-libegl-cos7-aarch64 ==18.3.4
+    - mesa-libegl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/mesa-libegl-devel-cos7-ppc64le/build.sh
+++ b/legacy_cdts/mesa-libegl-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libegl-devel-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/mesa-libegl-devel-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-libegl-cos7-ppc64le ==18.3.4
+    - mesa-libegl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - mesa-libegl-cos7-ppc64le ==18.3.4
+    - mesa-libegl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - mesa-libegl-cos7-ppc64le ==18.3.4
+    - mesa-libegl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/mesa-libgbm-cos6-x86_64/build.sh
+++ b/legacy_cdts/mesa-libgbm-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libgbm-cos7-aarch64/build.sh
+++ b/legacy_cdts/mesa-libgbm-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libgbm-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/mesa-libgbm-cos7-aarch64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/mesa-libgbm-cos7-ppc64le/build.sh
+++ b/legacy_cdts/mesa-libgbm-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libgbm-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/mesa-libgbm-cos7-ppc64le/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/mesa-libgl-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/mesa-libgl-cos6-x86_64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - libx11-cos6-x86_64 >1.6
-    - libdrm-cos6-x86_64 >=2.4.24
+    - libx11-cos6-x86_64 >1.6 *_{{ cdt_build_number }}
+    - libdrm-cos6-x86_64 >=2.4.24 *_{{ cdt_build_number }}
   host:
-    - libx11-cos6-x86_64 >1.6
-    - libdrm-cos6-x86_64 >=2.4.24
+    - libx11-cos6-x86_64 >1.6 *_{{ cdt_build_number }}
+    - libdrm-cos6-x86_64 >=2.4.24 *_{{ cdt_build_number }}
   run:
-    - libx11-cos6-x86_64 >1.6
-    - libdrm-cos6-x86_64 >=2.4.24
+    - libx11-cos6-x86_64 >1.6 *_{{ cdt_build_number }}
+    - libdrm-cos6-x86_64 >=2.4.24 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/mesa-libgl-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/mesa-libgl-cos7-aarch64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - libdrm-cos7-aarch64 >=2.4.83
-    - mesa-libglapi-cos7-aarch64 ==18.3.4
+    - libdrm-cos7-aarch64 >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/mesa-libgl-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/mesa-libgl-cos7-ppc64le/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - libdrm-cos7-ppc64le >=2.4.83
-    - mesa-libglapi-cos7-ppc64le ==18.3.4
+    - libdrm-cos7-ppc64le >=2.4.83 *_{{ cdt_build_number }}
+    - mesa-libglapi-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/mesa-libgl-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/mesa-libgl-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libgl-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/mesa-libgl-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-libgl-cos6-x86_64 ==11.0.7
+    - mesa-libgl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number }}
   host:
-    - mesa-libgl-cos6-x86_64 ==11.0.7
+    - mesa-libgl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number }}
   run:
-    - mesa-libgl-cos6-x86_64 ==11.0.7
+    - mesa-libgl-cos6-x86_64 ==11.0.7 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/legacy_cdts/mesa-libgl-devel-cos7-aarch64/build.sh
+++ b/legacy_cdts/mesa-libgl-devel-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libgl-devel-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/mesa-libgl-devel-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-libgl-cos7-aarch64 ==18.3.4
+    - mesa-libgl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - mesa-libgl-cos7-aarch64 ==18.3.4
+    - mesa-libgl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - mesa-libgl-cos7-aarch64 ==18.3.4
+    - mesa-libgl-cos7-aarch64 ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/mesa-libgl-devel-cos7-ppc64le/build.sh
+++ b/legacy_cdts/mesa-libgl-devel-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/mesa-libgl-devel-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/mesa-libgl-devel-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - mesa-libgl-cos7-ppc64le ==18.3.4
+    - mesa-libgl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   host:
-    - mesa-libgl-cos7-ppc64le ==18.3.4
+    - mesa-libgl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run:
-    - mesa-libgl-cos7-ppc64le ==18.3.4
+    - mesa-libgl-cos7-ppc64le ==18.3.4 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/nspr-cos7-aarch64/build.sh
+++ b/legacy_cdts/nspr-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nspr-cos7-ppc64le/build.sh
+++ b/legacy_cdts/nspr-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-cos7-aarch64/build.sh
+++ b/legacy_cdts/nss-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/nss-cos7-aarch64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   host:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   run:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/nss-cos7-ppc64le/build.sh
+++ b/legacy_cdts/nss-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/nss-cos7-ppc64le/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   host:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   run:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/nss-softokn-cos7-aarch64/build.sh
+++ b/legacy_cdts/nss-softokn-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-softokn-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/nss-softokn-cos7-aarch64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   host:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   run:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/nss-softokn-cos7-ppc64le/build.sh
+++ b/legacy_cdts/nss-softokn-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-softokn-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/nss-softokn-cos7-ppc64le/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   host:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   run:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/nss-softokn-freebl-cos7-aarch64/build.sh
+++ b/legacy_cdts/nss-softokn-freebl-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-softokn-freebl-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/nss-softokn-freebl-cos7-aarch64/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   host:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   run:
-    - nspr-cos7-aarch64 >=4.21.0
-    - nss-util-cos7-aarch64 >=3.44.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-aarch64 >=3.44.0 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/nss-softokn-freebl-cos7-ppc64le/build.sh
+++ b/legacy_cdts/nss-softokn-freebl-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-softokn-freebl-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/nss-softokn-freebl-cos7-ppc64le/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   host:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   run:
-    - nspr-cos7-ppc64le >=4.21.0
-    - nss-util-cos7-ppc64le >=3.44.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
+    - nss-util-cos7-ppc64le >=3.44.0 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/nss-util-cos7-aarch64/build.sh
+++ b/legacy_cdts/nss-util-cos7-aarch64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-util-cos7-aarch64/meta.yaml
+++ b/legacy_cdts/nss-util-cos7-aarch64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-aarch64 >=4.21.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
   host:
-    - nspr-cos7-aarch64 >=4.21.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
   run:
-    - nspr-cos7-aarch64 >=4.21.0
+    - nspr-cos7-aarch64 >=4.21.0 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-aarch64 ==99999999999
 

--- a/legacy_cdts/nss-util-cos7-ppc64le/build.sh
+++ b/legacy_cdts/nss-util-cos7-ppc64le/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/powerpc64le-conda_cos7-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/nss-util-cos7-ppc64le/meta.yaml
+++ b/legacy_cdts/nss-util-cos7-ppc64le/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - nspr-cos7-ppc64le >=4.21.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
   host:
-    - nspr-cos7-ppc64le >=4.21.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
   run:
-    - nspr-cos7-ppc64le >=4.21.0
+    - nspr-cos7-ppc64le >=4.21.0 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-ppc64le ==99999999999
 

--- a/legacy_cdts/numactl-cos6-x86_64/build.sh
+++ b/legacy_cdts/numactl-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/numactl-devel-cos6-x86_64/build.sh
+++ b/legacy_cdts/numactl-devel-cos6-x86_64/build.sh
@@ -2,7 +2,9 @@
 
 set -o errexit -o pipefail
 
-mkdir -p "${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+SYSROOT_DIR="${PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot
+
+mkdir -p "${SYSROOT_DIR}"
 if [[ -d usr/lib ]]; then
   if [[ ! -d lib ]]; then
     ln -s usr/lib lib
@@ -14,5 +16,5 @@ if [[ -d usr/lib64 ]]; then
   fi
 fi
 pushd ${SRC_DIR}/binary > /dev/null 2>&1
-rsync -K -a . "${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot"
+rsync -K -a . "${SYSROOT_DIR}"
 popd

--- a/legacy_cdts/numactl-devel-cos6-x86_64/meta.yaml
+++ b/legacy_cdts/numactl-devel-cos6-x86_64/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   build:
-    - numactl-cos6-x86_64 ==2.0.9
+    - numactl-cos6-x86_64 ==2.0.9 *_{{ cdt_build_number }}
   host:
-    - numactl-cos6-x86_64 ==2.0.9
+    - numactl-cos6-x86_64 ==2.0.9 *_{{ cdt_build_number }}
   run:
-    - numactl-cos6-x86_64 ==2.0.9
+    - numactl-cos6-x86_64 ==2.0.9 *_{{ cdt_build_number }}
   run_constrained:
     - sysroot_linux-64 ==99999999999
 

--- a/print_all_pkg_names.py
+++ b/print_all_pkg_names.py
@@ -1,0 +1,60 @@
+import os
+import glob
+import io
+from contextlib import redirect_stdout, redirect_stderr
+
+import tqdm
+from wurlitzer import pipes
+
+from cdt_config import (
+    LEGACY_CDT_PATH,
+    LEGACY_CUSTOM_CDT_PATH,
+    CDT_PATH,
+    CUSTOM_CDT_PATH,
+)
+
+
+def _get_pkg_name(recipe):
+    import conda_build.api
+
+    try:
+        f = io.StringIO()
+        with redirect_stdout(f), redirect_stderr(f), pipes(stdout=f, stderr=f):
+            metas = conda_build.api.render(
+                recipe,
+                variant_config_files=["conda_build_config.yaml"],
+                bypass_env_check=True,
+            )
+    except Exception as e:
+        print(f.getvalue())
+        raise e
+
+    dist_fnames = [
+        "noarch/" + os.path.basename(path)
+        for m, _, _ in metas
+        for path in conda_build.api.get_output_file_paths(m)
+        if not m.skip()
+    ]
+    return dist_fnames
+
+
+def print_names():
+    recipes = set(
+        glob.glob(CDT_PATH + "/*")
+        + glob.glob(CUSTOM_CDT_PATH + "/*")
+        + glob.glob(LEGACY_CDT_PATH + "/*")
+        + glob.glob(LEGACY_CUSTOM_CDT_PATH + "/*")
+    )
+    recipes = sorted(
+        r for r in recipes if not r.endswith("README.md")
+    )
+
+    names = []
+    for recipe in tqdm.tqdm(recipes, desc='rendering recipes'):
+        names += _get_pkg_name(recipe)
+    for name in sorted(names):
+        print(name)
+
+
+if __name__ == '__main__':
+    print_names()

--- a/rpm.py
+++ b/rpm.py
@@ -589,6 +589,12 @@ def write_conda_recipes(
     conda_forge_style,
     single_sysroot,
 ):
+
+    if single_sysroot:
+        build_number_jinja2 = "{{ cdt_build_number|int + 1000 }}"
+    else:
+        build_number_jinja2 = "{{ cdt_build_number }}"
+
     entry, entry_name, arch = find_repo_entry_and_arch(
         repo_primary, architectures, dict({"name": package})
     )
@@ -669,12 +675,13 @@ def write_conda_recipes(
     dependsstr = ""
     if len(depends) or conda_forge_style:
         depends_specs = [
-            "{}-{}-{} {}{}".format(
+            "{}-{}-{} {}{} *_{}".format(
                 depend["name"].lower().replace("+", "x"),
                 cdt["short_name"],
                 depend["arch"],
                 depend["flags"],
                 depend["ver"],
+                build_number_jinja2,
             )
             for depend in depends
         ]
@@ -726,11 +733,7 @@ def write_conda_recipes(
     d = dict(
         {
             "version": entry["version"]["ver"],
-            "build_number": (
-                "{{ cdt_build_number|int + 1000 }}"
-                if single_sysroot
-                else "{{ cdt_build_number }}"
-            ),
+            "build_number": build_number_jinja2,
             "license_file": license_file,
             "packagename": package_cdt_name,
             "hostmachine": cdt["host_machine"],


### PR DESCRIPTION
Please see the repo readme for directions on how to make PRs on this repo.

Checklist:

- [ ] if you have added a CDT, it appears in the `cdt_slugs.yaml` file
- [ ] if you have changed the CDT generator code (`rpm.py`), you have bumped
  the build number in `conda_build_config.yaml` and have remade all of the
  recipes via running `python gen_cdt_recipes.py`
- [ ] if you have added a custom CDT recipe, you have added the name of the CDT
  with `custom: true` in the `cdt_slugs.yaml` file.
- [ ] all CDT recipes have build number set by `{{ cdt_build_number }}` for
  old-style/legacy CDTs or `{{ cdt_build_number|int + 1000 }}` for new-style CDTs
- [ ] if you see a warning about a CDT not having a license, you have added the
  `license_file` key in the `cdt_slugs.yaml` file with the path to the appropriate
  license in `licenses/`
