### PR TITLE
Do not use removed iteritems from conda_build

### DIFF
--- a/rpm.py
+++ b/rpm.py
@@ -53,7 +53,6 @@ import tempfile
 import subprocess
 
 import click
-from conda_build.conda_interface import iteritems
 from conda_build.source import download_to_cache
 from conda_build.license_family import guess_license_family
 from conda_build.config import Config
@@ -340,7 +339,7 @@ def find_repo_entry_and_arch(repo_primary, architectures, depend):
         found_package_name = dep_name
     except Exception:
         # Look through the provides of all packages.
-        for name, package in iteritems(repo_primary):
+        for name, package in repo_primary.items():
             for arch in architectures:
                 if arch in package:
                     if "provides" in package[arch]:
@@ -904,7 +903,7 @@ def write_conda_recipe(
         }
     )
     cdt = dict()
-    for k, v in iteritems(cdt_info[cdt_name]):
+    for k, v in cdt_info[cdt_name].items():
         if isinstance(v, string_types):
             cdt[k] = v.format(**architecture_bits)
         else:


### PR DESCRIPTION
Do I really need to bump the cdt number in https://github.com/conda-forge/cdt-builds#changing-the-cdt-generation-script-rpmpy

it seems that this is just a problem with the generation script.

Please see the repo readme for directions on how to make PRs on this repo.

Checklist:

- [ ] if you have added a CDT, it appears in the `cdt_slugs.yaml` file and
  you have rerun the script `python gen_cdt_recipes.py`.
- [ ] if you have changed the CDT generator code (`rpm.py`), you have bumped
  the build number in `conda_build_config.yaml` and have remade all of the
  recipes via running `python gen_cdt_recipes.py --force`
- [ ] if you have added a custom CDT recipe, you have added the name of the CDT
  with `custom: true` in the `cdt_slugs.yaml` file.
- [ ] all CDT recipes have build number set by `{{ cdt_build_number }}` for
  old-style/legacy CDTs or `{{ cdt_build_number|int + 1000 }}` for new-style CDTs
- [ ] if you see a warning about a CDT not having a license, you have added the
  `license_file` key in the `cdt_slugs.yaml` file with the path to the appropriate
  license in `licenses/`

**NOTE: If you make any changes to `cd_slugs.yaml`, you need to reun the generator code
via `python gen_cdt_recipes.py`.**
