### PR TITLE
Stop using conda_build.conda_interface

### DIFF
--- a/build_cdt_recipes.py
+++ b/build_cdt_recipes.py
@@ -12,7 +12,7 @@ import tqdm
 import click
 from ruamel.yaml import YAML
 
-from conda_build.conda_interface import get_index
+from conda.core.index import get_index
 
 from cdt_config import (
     LEGACY_CDT_PATH,
@@ -95,15 +95,14 @@ def _get_recipe_attrs(recipe, channel_index):
 def _build_cdt_meta(recipes, dist_arch_slug):
     print("getting conda-forge/label/main channel index...", flush=True)
     channel_url = '/'.join(['conda-forge', 'label', 'main'])
-    dist_index = get_index(
-        [channel_url],
-        prepend=False,
-        use_cache=False
-    )
     channel_index = {
-        c.to_filename(): a
-        for c, a in dist_index.items()
-        if a['subdir'] == 'noarch'
+        prec.fn: prec
+        for prec in get_index(
+            [channel_url],
+            prepend=False,
+            use_cache=False,
+        )
+        if prec.subdir == 'noarch'
     }
 
     cdt_meta = {}


### PR DESCRIPTION
`conda_build.conda_interface` is being deprecated.

`conda_build.conda_interface.get_index` (which is `conda.exports.get_index`) is using the `conda.models.Dist` -> `conda.models.records.PackageRecord` mapping. `Dist` class is legacy code that's being phased out, so avoid it.

refs:
- https://github.com/conda/conda-build/pull/5152
- https://github.com/conda/conda-build/pull/5222

Please see the repo readme for directions on how to make PRs on this repo.

Checklist:

- [ ] if you have added a CDT, it appears in the `cdt_slugs.yaml` file and
  you have rerun the script `python gen_cdt_recipes.py`.
- [ ] if you have changed the CDT generator code (`rpm.py`), you have bumped
  the build number in `conda_build_config.yaml` and have remade all of the
  recipes via running `python gen_cdt_recipes.py --force`
- [ ] if you have added a custom CDT recipe, you have added the name of the CDT
  with `custom: true` in the `cdt_slugs.yaml` file.
- [ ] all CDT recipes have build number set by `{{ cdt_build_number }}` for
  old-style/legacy CDTs or `{{ cdt_build_number|int + 1000 }}` for new-style CDTs
- [ ] if you see a warning about a CDT not having a license, you have added the
  `license_file` key in the `cdt_slugs.yaml` file with the path to the appropriate
  license in `licenses/`

**NOTE: If you make any changes to `cd_slugs.yaml`, you need to reun the generator code
via `python gen_cdt_recipes.py`.**
