### PR TITLE
fix: Minor usability fixes to the rpm script

### DIFF
--- a/rpm.py
+++ b/rpm.py
@@ -407,7 +407,7 @@ def get_repo_dict(repomd_url, data_type, dict_massager, cdt, src_cache):
     repomd = ET.fromstring(xmlstring)
     for child in repomd.findall("*[@type='{}']".format(data_type)):
         open_csum = child.findall("open-checksum")[0].text
-        xml_file = join(src_cache, open_csum)
+        xml_file = join(src_cache, f"{open_csum}.xml")
         try:
             xml_file, xml_csum = cache_file(
                 src_cache, xml_file, None, cdt["checksummer"]

--- a/rpm.py
+++ b/rpm.py
@@ -401,7 +401,9 @@ def dictify_pickled(xml_file, src_cache, dict_massager=None, cdt=None):
 
 
 def get_repo_dict(repomd_url, data_type, dict_massager, cdt, src_cache):
-    xmlstring = request("get", repomd_url).content
+    response = request("get", repomd_url)
+    response.raise_for_status()
+    xmlstring = response.content
     # Remove the default namespace definition (xmlns="http://some/namespace")
     xmlstring = re.sub(rb'\sxmlns="[^"]+"', b"", xmlstring, count=1)  # noqa
     try:

--- a/rpm.py
+++ b/rpm.py
@@ -404,7 +404,10 @@ def get_repo_dict(repomd_url, data_type, dict_massager, cdt, src_cache):
     xmlstring = request("get", repomd_url).content
     # Remove the default namespace definition (xmlns="http://some/namespace")
     xmlstring = re.sub(rb'\sxmlns="[^"]+"', b"", xmlstring, count=1)  # noqa
-    repomd = ET.fromstring(xmlstring)
+    try:
+        repomd = ET.fromstring(xmlstring)
+    except ET.ParseError as parse_error:
+        raise RuntimeError(f"Error parsing {repomd_url}") from parse_error
     for child in repomd.findall("*[@type='{}']".format(data_type)):
         open_csum = child.findall("open-checksum")[0].text
         xml_file = join(src_cache, f"{open_csum}.xml")


### PR DESCRIPTION
A bunch of small fixes related to me debugging an XML parsing failure:

1. Store cached XML files with `.xml` suffix.
2. Include the processed URL in the exception when XML parsing error happens.
3. Actually check HTTP status code.